### PR TITLE
Add unit test for MainViewModel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.25.1"
     testImplementation 'org.robolectric:robolectric:4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
+    testImplementation 'androidx.arch.core:core-testing:2.0.0'
     androidTestImplementation 'androidx.test:runner:1.1.2-alpha02'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0-alpha02'
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/app/src/main/java/br/com/sabinotech/chucknorris/ui/viewmodels/ViewModelFactory.kt
+++ b/app/src/main/java/br/com/sabinotech/chucknorris/ui/viewmodels/ViewModelFactory.kt
@@ -2,6 +2,7 @@ package br.com.sabinotech.chucknorris.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import io.reactivex.android.schedulers.AndroidSchedulers
 import org.kodein.di.DKodein
 import org.kodein.di.generic.instance
 import org.kodein.di.newInstance
@@ -10,7 +11,7 @@ class ViewModelFactory(private val injector: DKodein) : ViewModelProvider.Factor
 
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-            return injector.newInstance { MainViewModel(instance(), instance()) } as T
+            return injector.newInstance { MainViewModel(instance(), instance(), AndroidSchedulers.mainThread()) } as T
         }
 
         return modelClass.newInstance()

--- a/app/src/test/java/br/com/sabinotech/chucknorris/common/TestObserver.kt
+++ b/app/src/test/java/br/com/sabinotech/chucknorris/common/TestObserver.kt
@@ -1,0 +1,17 @@
+package br.com.sabinotech.chucknorris.common
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+
+class TestObserver<T> : Observer<T> {
+
+    val observedValues = mutableListOf<T?>()
+
+    override fun onChanged(value: T?) {
+        observedValues.add(value)
+    }
+}
+
+fun <T> LiveData<T>.testObserver() = TestObserver<T>().also {
+    observeForever(it)
+}

--- a/app/src/test/java/br/com/sabinotech/chucknorris/ui/viewmodels/MainViewModelTest.kt
+++ b/app/src/test/java/br/com/sabinotech/chucknorris/ui/viewmodels/MainViewModelTest.kt
@@ -1,0 +1,77 @@
+package br.com.sabinotech.chucknorris.ui.viewmodels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import br.com.sabinotech.chucknorris.common.testObserver
+import br.com.sabinotech.chucknorris.data.repositories.FactsRepository
+import br.com.sabinotech.chucknorris.domain.Fact
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+
+class MainViewModelTest {
+
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val factsRepository by lazy { mock(FactsRepository::class.java) }
+    private val networkStateOnline by lazy { Observable.just(true) }
+    private val networkStateOffline by lazy { Observable.just(false) }
+    private val mainViewModel by lazy { MainViewModel(factsRepository, networkStateOnline, Schedulers.trampoline()) }
+
+    @Test
+    fun `getFacts first state must be a empty`() {
+        val testObserver = mainViewModel.isLoading().testObserver()
+        Assert.assertEquals(listOf<Fact>(), testObserver.observedValues)
+    }
+
+    @Test
+    fun `isLoading first state must be empty`() {
+        val testObserver = mainViewModel.isLoading().testObserver()
+        Assert.assertEquals(listOf<Boolean>(), testObserver.observedValues)
+    }
+
+    @Test
+    fun `when internet connection is available isInternetAvailable must be true`() {
+        val testObserver = mainViewModel.isInternetAvailable().testObserver()
+        Assert.assertEquals(listOf(true), testObserver.observedValues)
+    }
+
+    @Test
+    fun `when internet connection is unavailable isInternetAvailable must be false`() {
+        val mainViewModel = MainViewModel(factsRepository, networkStateOffline, Schedulers.trampoline())
+
+        val testObserver = mainViewModel.isInternetAvailable().testObserver()
+        Assert.assertEquals(listOf(false), testObserver.observedValues)
+    }
+
+    @Test
+    fun `when searchTerm is set the facts must be updated`() {
+        val expectedFacts = listOf(
+            Fact("a2", "http://google.com", "Dev Joke 1", "DEV")
+        )
+
+        `when`(factsRepository.queryFacts("DEV")).thenReturn(Single.just(expectedFacts))
+
+        val testObserver = mainViewModel.getFacts().testObserver()
+
+        mainViewModel.setSearchTerm("DEV")
+        Assert.assertEquals(listOf(listOf(), expectedFacts), testObserver.observedValues)
+    }
+
+    @Test
+    fun `when searchTerm is set the loading must be triggered`() {
+        `when`(factsRepository.queryFacts("DEV")).thenReturn(Single.just(listOf()))
+
+        val testObserver = mainViewModel.isLoading().testObserver()
+
+        mainViewModel.setSearchTerm("DEV")
+        Assert.assertEquals(listOf(true, false), testObserver.observedValues)
+    }
+}


### PR DESCRIPTION
The MainViewModel now requires a observable interface for networkState instead of a concrete class
The scheduler was injected to remove the static dependency and allow the test to inject a different instance

This closes #12 