### PR TITLE
Error handling and visualization of them on view through snackbar

### DIFF
--- a/app/src/main/java/br/com/sabinotech/chucknorris/ui/SearchFragment.kt
+++ b/app/src/main/java/br/com/sabinotech/chucknorris/ui/SearchFragment.kt
@@ -16,11 +16,13 @@ import br.com.sabinotech.chucknorris.ui.adapters.TagCloudAdapter
 import br.com.sabinotech.chucknorris.ui.common.BaseFragment
 import com.google.android.flexbox.FlexboxLayoutManager
 import kotlinx.android.synthetic.main.fragment_search.*
+import kotlinx.android.synthetic.main.fragment_search.view.*
 
 const val NUMBER_OF_DISPLAYED_TAGS = 8
 
 class SearchFragment : BaseFragment() {
 
+    private lateinit var snackbarRoot: ViewGroup
     private lateinit var onChangeSearchTermListener: OnChangeSearchTermListener
 
     override fun onAttach(context: Context) {
@@ -38,14 +40,18 @@ class SearchFragment : BaseFragment() {
         return inflater.inflate(R.layout.fragment_search, container, false)
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        snackbarRoot = view!!.fragmentSearchMainLayout
 
         setSearchTermListener()
 
         initCategoriesObserver()
 
         initPastSearchesObserver()
+
+        initErrorObserver(snackbarRoot)
     }
 
     private fun setSearchTermListener() {

--- a/app/src/main/java/br/com/sabinotech/chucknorris/ui/common/BaseFragment.kt
+++ b/app/src/main/java/br/com/sabinotech/chucknorris/ui/common/BaseFragment.kt
@@ -1,9 +1,12 @@
 package br.com.sabinotech.chucknorris.ui.common
 
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import br.com.sabinotech.chucknorris.ui.viewmodels.MainViewModel
+import com.google.android.material.snackbar.Snackbar
 import org.kodein.di.Kodein
 import org.kodein.di.KodeinAware
 import org.kodein.di.android.x.kodein
@@ -17,5 +20,11 @@ abstract class BaseFragment : Fragment(), KodeinAware {
         activity?.run {
             ViewModelProviders.of(this, viewModeFactory).get(MainViewModel::class.java)
         } ?: throw Exception("Invalid activity")
+    }
+
+    protected fun initErrorObserver(snackbarRoot: ViewGroup) {
+        viewModel.getErrors().observe(viewLifecycleOwner, Observer {
+            Snackbar.make(snackbarRoot, it, Snackbar.LENGTH_SHORT).show()
+        })
     }
 }

--- a/app/src/main/java/br/com/sabinotech/chucknorris/ui/common/SingleLiveEvent.java
+++ b/app/src/main/java/br/com/sabinotech/chucknorris/ui/common/SingleLiveEvent.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2017 Google Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package br.com.sabinotech.chucknorris.ui.common;
+
+import android.util.Log;
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A lifecycle-aware observable that sends only new updates after subscription, used for events like
+ * navigation and Snackbar messages.
+ * <p>
+ * This avoids a common problem with events: on configuration change (like rotation) an update
+ * can be emitted if the observer is active. This LiveData only calls the observable if there's an
+ * explicit call to setValue() or call().
+ * <p>
+ * Note that only one observer is going to be notified of changes.
+ */
+public class SingleLiveEvent<T> extends MutableLiveData<T> {
+
+    private static final String TAG = "SingleLiveEvent";
+
+    private final AtomicBoolean mPending = new AtomicBoolean(false);
+
+    @Override
+    public void observe(@NonNull LifecycleOwner owner, @NonNull final Observer<? super T> observer) {
+
+        if (hasActiveObservers()) {
+            Log.w(TAG, "Multiple observers registered but only one will be notified of changes.");
+        }
+
+        // Observe the internal MutableLiveData
+        super.observe(owner, new Observer<T>() {
+            @Override
+            public void onChanged(@Nullable T t) {
+                if (mPending.compareAndSet(true, false)) {
+                    observer.onChanged(t);
+                }
+            }
+        });
+    }
+
+    @MainThread
+    public void setValue(@Nullable T t) {
+        mPending.set(true);
+        super.setValue(t);
+    }
+
+    /**
+     * Used for cases where T is Void, to make calls cleaner.
+     */
+    @MainThread
+    public void call() {
+        setValue(null);
+    }
+}

--- a/app/src/main/res/layout/fragment_facts.xml
+++ b/app/src/main/res/layout/fragment_facts.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/mainLayout"
+    android:id="@+id/fragmentFactsMainLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.FactsFragment">

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragmentSearchMainLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.SearchFragment">


### PR DESCRIPTION
Function names were standardized between FactsFragment and SearchFragments
Using viewLifecycleOwner instead of "this" on fragments to avoid duplicated observers
Moving initialization of observers to onActivityCreated method on fragments

This closes #15 