### PR TITLE
Acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /build
 /captures
 .externalNativeBuild
+google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "br.com.sabinotech.chucknorris.UiTestRunner"
     }
     buildTypes {
         release {
@@ -43,8 +43,11 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'androidx.arch.core:core-testing:2.0.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test:runner:1.1.2-alpha02'
+    androidTestImplementation 'org.mockito:mockito-android:2.8.9'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0-alpha02'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0-alpha02'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'com.android.support:design:28.0.0'

--- a/app/src/androidTest/java/br/com/sabinotech/chucknorris/ChuckNorrisTestApplication.kt
+++ b/app/src/androidTest/java/br/com/sabinotech/chucknorris/ChuckNorrisTestApplication.kt
@@ -1,0 +1,49 @@
+package br.com.sabinotech.chucknorris
+
+import android.app.Application
+import androidx.room.Room
+import br.com.sabinotech.chucknorris.data.local.AppDatabase
+import br.com.sabinotech.chucknorris.data.repositories.FactsRepository
+import br.com.sabinotech.chucknorris.data.repositories.FactsRepositoryInterface
+import br.com.sabinotech.chucknorris.data.services.ChuckNorrisService
+import br.com.sabinotech.chucknorris.ui.common.NetworkState
+import br.com.sabinotech.chucknorris.ui.viewmodels.ViewModelFactory
+import org.kodein.di.DKodein
+import org.kodein.di.Kodein
+import org.kodein.di.KodeinAware
+import org.kodein.di.android.x.androidXModule
+import org.kodein.di.direct
+import org.kodein.di.generic.bind
+import org.kodein.di.generic.instance
+import org.kodein.di.generic.singleton
+import org.mockito.Mockito
+
+class ChuckNorrisTestApplication : Application(), KodeinAware {
+
+    override val kodein = Kodein.lazy {
+
+        import(androidXModule(this@ChuckNorrisTestApplication))
+
+        bind<DKodein>() with singleton { kodein.direct }
+
+        bind<FactsRepositoryInterface>() with singleton { FactsRepository(instance(), instance()) }
+
+        bind<ViewModelFactory>() with singleton { ViewModelFactory(instance()) }
+
+        bind<AppDatabase>() with singleton {
+            Room
+                .inMemoryDatabaseBuilder(
+                    applicationContext,
+                    AppDatabase::class.java
+                )
+                .build()
+        }
+
+        bind<ChuckNorrisService>() with singleton {
+            Mockito.mock(ChuckNorrisService::class.java)
+        }
+
+        bind<NetworkState>() with singleton { NetworkState() }
+
+    }
+}

--- a/app/src/androidTest/java/br/com/sabinotech/chucknorris/UiTestRunner.kt
+++ b/app/src/androidTest/java/br/com/sabinotech/chucknorris/UiTestRunner.kt
@@ -1,0 +1,14 @@
+package br.com.sabinotech.chucknorris
+
+import android.app.Application
+import android.app.Instrumentation
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+
+class UiTestRunner : AndroidJUnitRunner() {
+
+    @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
+    override fun newApplication(cl: ClassLoader, className: String, context: Context): Application {
+        return Instrumentation.newApplication(ChuckNorrisTestApplication::class.java, context)
+    }
+}

--- a/app/src/androidTest/java/br/com/sabinotech/chucknorris/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/br/com/sabinotech/chucknorris/ui/MainActivityTest.kt
@@ -20,6 +20,7 @@ import br.com.sabinotech.chucknorris.data.services.ChuckNorrisService
 import br.com.sabinotech.chucknorris.ui.adapters.TagCloudViewHolder
 import org.hamcrest.CoreMatchers
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,7 +43,12 @@ class MainActivityTest : KodeinAware {
     override val kodeinContext = kcontext(context)
     private val chuckNorrisService: ChuckNorrisService by instance()
     private val appDatabase: AppDatabase by instance()
-    private val serviceMock = SetupServiceMock(chuckNorrisService)
+    private lateinit var serviceMock: SetupServiceMock
+
+    @Before
+    fun setup() {
+        serviceMock = SetupServiceMock(chuckNorrisService)
+    }
 
     @Test
     fun checkIfTheFactsFragmentHasBeenLoaded() {
@@ -118,8 +124,8 @@ class MainActivityTest : KodeinAware {
         onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
 
         onView(ViewMatchers.withId(R.id.searchTagCloud)).perform(
-            RecyclerViewActions.actionOnItemAtPosition<TagCloudViewHolder>(
-                serviceMock.listOfCategories.indexOf(serviceMock.queryTermForSuccess),
+            RecyclerViewActions.actionOnItem<TagCloudViewHolder>(
+                ViewMatchers.withText(serviceMock.queryTermForSuccess),
                 ViewActions.click()
             )
         )

--- a/app/src/androidTest/java/br/com/sabinotech/chucknorris/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/br/com/sabinotech/chucknorris/ui/MainActivityTest.kt
@@ -1,0 +1,173 @@
+package br.com.sabinotech.chucknorris.ui
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import br.com.sabinotech.chucknorris.ChuckNorrisTestApplication
+import br.com.sabinotech.chucknorris.R
+import br.com.sabinotech.chucknorris.data.local.AppDatabase
+import br.com.sabinotech.chucknorris.data.local.model.Search
+import br.com.sabinotech.chucknorris.data.services.ChuckNorrisService
+import br.com.sabinotech.chucknorris.ui.adapters.TagCloudViewHolder
+import org.hamcrest.CoreMatchers
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kodein.di.Kodein
+import org.kodein.di.KodeinAware
+import org.kodein.di.generic.instance
+import org.kodein.di.generic.kcontext
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class MainActivityTest : KodeinAware {
+
+    @get:Rule
+    var activityTest = ActivityScenarioRule(MainActivity::class.java)
+    private val context = InstrumentationRegistry
+        .getInstrumentation()
+        .targetContext
+        .applicationContext as ChuckNorrisTestApplication
+    override val kodein: Kodein = context.kodein.baseKodein
+    override val kodeinContext = kcontext(context)
+    private val chuckNorrisService: ChuckNorrisService by instance()
+    private val appDatabase: AppDatabase by instance()
+    private val serviceMock = SetupServiceMock(chuckNorrisService)
+
+    @Test
+    fun checkIfTheFactsFragmentHasBeenLoaded() {
+        activityTest.scenario.onActivity {
+            val fragments = it.supportFragmentManager.fragments
+
+            Assert.assertEquals(1, fragments.size)
+            Assert.assertEquals(FactsFragment::class.java, fragments[0]::class.java)
+        }
+    }
+
+    @Test
+    fun checkIfTheFactsListIsEmpty() {
+        onView(ViewMatchers.withId(R.id.mainRecyclerView)).check { view, _ ->
+            Assert.assertEquals(RecyclerView::class.java, view::class.java)
+            val recyclerView = view as RecyclerView
+            Assert.assertNull(recyclerView.adapter)
+        }
+    }
+
+    @Test
+    fun whenClickSearchButtonMustShowSearchFragment() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        activityTest.scenario.onActivity {
+            val fragments = it.supportFragmentManager.fragments
+
+            Assert.assertEquals(1, fragments.size)
+            Assert.assertEquals(SearchFragment::class.java, fragments[0]::class.java)
+        }
+    }
+
+    @Test
+    fun whenPressBackButtonMustReturnToFactsFragment() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        Espresso.pressBack()
+
+        activityTest.scenario.onActivity {
+            val fragments = it.supportFragmentManager.fragments
+
+            Assert.assertEquals(1, fragments.size)
+            Assert.assertEquals(FactsFragment::class.java, fragments[0]::class.java)
+        }
+    }
+
+    @Test
+    fun checkIfTheTagsCloudIsFilled() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        onView(ViewMatchers.withId(R.id.searchTagCloud)).check { view, _ ->
+            Assert.assertEquals(RecyclerView::class.java, view::class.java)
+            val recyclerView = view as RecyclerView
+            Assert.assertNotNull(recyclerView.adapter)
+            Assert.assertEquals(serviceMock.listOfCategories.size, recyclerView.adapter?.itemCount)
+        }
+    }
+
+    @Test
+    fun checkFunctionalityOfSearchByTerm() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        onView(ViewMatchers.withId(R.id.searchTerm)).perform(
+            ViewActions.typeText(serviceMock.queryTermForSuccess),
+            ViewActions.pressImeActionButton()
+        )
+
+        assertThatFactsListIsDisplayedAndFilled()
+    }
+
+    @Test
+    fun checkFunctionalityOfSearchByTag() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        onView(ViewMatchers.withId(R.id.searchTagCloud)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<TagCloudViewHolder>(
+                serviceMock.listOfCategories.indexOf(serviceMock.queryTermForSuccess),
+                ViewActions.click()
+            )
+        )
+
+        assertThatFactsListIsDisplayedAndFilled()
+    }
+
+    @Test
+    fun checkFunctionalityOfSearchByClickOnPastSearch() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        appDatabase.searchDao().insert(Search(null, serviceMock.queryTermForSuccess)).subscribe()
+        appDatabase.searchDao().insert(Search(null, "other category")).subscribe()
+
+        Thread.sleep(500)
+
+        onData(CoreMatchers.anything())
+            .inAdapterView(ViewMatchers.withId(R.id.pastSearches))
+            .atPosition(1)
+            .perform(ViewActions.click())
+
+        assertThatFactsListIsDisplayedAndFilled()
+    }
+
+    @Test
+    fun checkIfSnackbarIsDisplayedWhenAnErrorOccurs() {
+        onView(ViewMatchers.withId(R.id.action_search)).perform(ViewActions.click())
+
+        onView(ViewMatchers.withId(R.id.searchTerm)).perform(
+            ViewActions.typeText(serviceMock.queryTermForError),
+            ViewActions.pressImeActionButton()
+        )
+
+        Thread.sleep(500)
+
+        onView(ViewMatchers.withId(com.google.android.material.R.id.snackbar_text))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        onView(ViewMatchers.withId(com.google.android.material.R.id.snackbar_text))
+            .check(ViewAssertions.matches(ViewMatchers.withText("There was an error loading the facts")))
+    }
+
+    private fun assertThatFactsListIsDisplayedAndFilled() {
+        onView(ViewMatchers.withId(R.id.mainRecyclerView)).check { view, _ ->
+            Assert.assertEquals(RecyclerView::class.java, view::class.java)
+            val recyclerView = view as RecyclerView
+
+            Assert.assertNotNull(recyclerView.adapter)
+            Assert.assertEquals(serviceMock.listOfFacts.size, recyclerView.adapter?.itemCount)
+        }
+    }
+}

--- a/app/src/androidTest/java/br/com/sabinotech/chucknorris/ui/SetupServiceMock.kt
+++ b/app/src/androidTest/java/br/com/sabinotech/chucknorris/ui/SetupServiceMock.kt
@@ -1,0 +1,46 @@
+package br.com.sabinotech.chucknorris.ui
+
+import br.com.sabinotech.chucknorris.data.services.ChuckNorrisService
+import br.com.sabinotech.chucknorris.data.services.QueryFactsResponse
+import br.com.sabinotech.chucknorris.data.services.QueryFactsResponseItem
+import io.reactivex.Single
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import org.mockito.Mockito.`when`
+import retrofit2.Response
+
+class SetupServiceMock(private val chuckNorrisService: ChuckNorrisService) {
+
+    val queryTermForSuccess = "dev"
+    val queryTermForError = "Internal server error"
+    val listOfCategories = listOf("dev", "political")
+    val listOfFacts = listOf(QueryFactsResponseItem("a1", "http://google.com", "Fact 1", null))
+
+    init {
+        mockResponseOfNormalQuery()
+
+        mockResponseOfErrorInQuery()
+
+        mockResponseOfGetCategories()
+    }
+
+    private fun mockResponseOfNormalQuery() {
+        val expectedResponse1 = Response.success(QueryFactsResponse(listOfFacts))
+
+        `when`(chuckNorrisService.queryFacts(queryTermForSuccess))
+            .thenReturn(Single.just(expectedResponse1))
+    }
+
+    private fun mockResponseOfErrorInQuery() {
+        val expectedResponseBody = ResponseBody.create(MediaType.get("text/plain"), "Internal server error")
+        val expectedResponse2 = Response.error<QueryFactsResponse>(500, expectedResponseBody)
+
+        `when`(chuckNorrisService.queryFacts(queryTermForError))
+            .thenReturn(Single.just(expectedResponse2))
+    }
+
+    private fun mockResponseOfGetCategories() {
+        `when`(chuckNorrisService.getCategories())
+            .thenReturn(Single.just(listOfCategories))
+    }
+}


### PR DESCRIPTION
The Retrofit service was mocked using Mockito to accelerate the execution of tests and provide a stable response
The database was changed to be in memory
The lib espresso was used to test the view behavior

This closes #21 